### PR TITLE
BindWinEvent fixes/changes.

### DIFF
--- a/Source/bindwinevent.PRG
+++ b/Source/bindwinevent.PRG
@@ -3,6 +3,10 @@
 LPARAMETERS thWnd, tnMessage, toEventHandler, tcDelegate, tnFlags
 Local lnReturn
 
+IF !('BINDWINEVENTAPI' $ Upper(SET( 'Procedure' )))
+	SET PROCEDURE TO BindWinEventAPI ADDITIVE
+ENDIF
+
 IF !PEMSTATUS(_SCREEN,"oEventHandler",5) or IsNull(_Screen.oEventHandler)
 	_SCREEN.NewObject("oEventHandler","VFPxWin32EventHandler","VFPxWin32EventHandler.prg")
 EndIf

--- a/Source/bindwineventapi.prg
+++ b/Source/bindwineventapi.prg
@@ -15,31 +15,3 @@ LPARAMETERS hWnd, nIndex
 	Declare Integer GetWindowLong In Win32API Integer hWnd, Integer nIndex
 	RETURN GetWindowLong(hWnd, nIndex)
 ENDFUNC
-
-
-FUNCTION FindWindowEx
-LPARAMETERS hWndParent, hwndChildAfter, lpszClass, lpszWindow
-	Declare Integer FindWindowEx In Win32API Integer hWndParent, Integer hwndChildAfter, String lpszClass, String lpszWindow
-	RETURN FindWindowEx(hWndParent, hwndChildAfter, lpszClass, lpszWindow)
-ENDFUNC
-
-
-FUNCTION GetWindowInfo
-LPARAMETERS hWnd, pwindowinfo
-	Declare Integer GetWindowInfo In Win32API Integer hWnd, String @ pwindowinfo
-	RETURN GetWindowInfo(hWnd, @pwindowinfo)
-ENDFUNC
-
-
-FUNCTION GetWindowText
-LPARAMETERS hWnd, szText, nLen
-	Declare Integer GetWindowText In Win32API Integer hWnd, String @szText, Integer nLen
-	RETURN GetWindowText(hWnd, @szText, nLen)
-ENDFUNC
-
-
-FUNCTION GetAncestor 
-LPARAMETERS hWnd, gaFlags
-	Declare Integer GetAncestor In Win32API Integer hWnd, Integer gaFlags
-	RETURN GetAncestor(hWnd, gaFlags)
-ENDFUNC

--- a/Source/vfpxwin32eventhandler.prg
+++ b/Source/vfpxwin32eventhandler.prg
@@ -70,8 +70,8 @@ DEFINE CLASS VFPxWin32EventHandler AS Collection
 			this.hdlDebug = FCREATE("GKKWin32EventHandler.log",0)
 		ENDIF
 		
-		IF !('FoxTabsDeclareAPI' $ SET( 'Procedure' ))
-			SET PROCEDURE TO FoxTabsDeclareAPI ADDITIVE
+		IF !('BINDWINEVENTAPI' $ Upper(SET( 'Procedure' )))
+			SET PROCEDURE TO BindWinEventAPI ADDITIVE
 		ENDIF
 
 		* Store handle for use in CallWindowProc
@@ -120,7 +120,9 @@ DEFINE CLASS VFPxWin32EventHandler AS Collection
 			EndIf 
 		Otherwise
 			Assert .f. Message "UnBindEvents requires 1, 2, or 4 parameters. Syntax: " + Chr(13) + Chr(13) + ;
-				"UnBindEvents(oEventObject)" + Chr(13) + "UnBindEvents(thWnd, tnMessage, toEventHandler, tcDelegate)"
+				"UnBindEvents(oEventObject)" + Chr(13) + ;
+				"UnBindEvents(thWnd, tnMessage)" + Chr(13) + ;
+				"UnBindEvents(thWnd, tnMessage, toEventHandler, tcDelegate)"
 		ENDCASE
 
 		This.CleanupEvents()
@@ -145,7 +147,7 @@ DEFINE CLASS VFPxWin32EventHandler AS Collection
 			* Check if there are any bindings for this Win event
 			For lnRow = 1 to lnEvents
 				If laWinEvents[lnRow,1] = loWinEvent.hWnd and ;
-					laWinEvents[lnRow,2] = loWinEvent.nMessage
+						laWinEvents[lnRow,2] = loWinEvent.nMessage
 					llEventFound = .t.
 					Exit 
 				EndIf 


### PR DESCRIPTION
Since we both have dependencies on it, I moved BindWinEvent into a separate repository (https://github.com/JoelLeach/BindWinEvent) and applied your fixes.  In the process, I moved applicable API calls from FoxTabsDeclareAPI.prg to BindWinEventAPI.prg.  I have been running FoxTabs and ProjectExplorer with these changes for a few months without issues.
